### PR TITLE
Allow custom character sets in Ranker

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@ You can use the ranker stand-alone via the `LexoRanker::Ranker` class.
 
 ```ruby
 # Use `.only` to get the first ranking of a set.
-LexoRanker::Ranker.only # => "M"
+LexoRanker::Ranker.new.only # => "M"
 
 # Use `.between` to get the ranking of an element between two other rankings
-LexoRanker::Ranker.between("M", "T") # => "R"
+LexoRanker::Ranker.new.between("M", "T") # => "R"
 
 # Use `.first` to get the ranking that comes before the first element
-LexoRanker::Ranker.first("M") # => "H"
+LexoRanker::Ranker.new.first("M") # => "H"
 
 # Use `.init_from_enumerable(enum_list)` to generate a rank for each element
 # in an already sorted list of elements, returns a hash with the elements as
 # the keys and the rank as values.
 list = %w[my sorted list]
-LexoRanker::Ranker.init_from_enumerable(list) # { "my" => "M", "sorted" => "R", "list" => "t"}
+LexoRanker::Ranker.new.init_from_enumerable(list) # { "my" => "M", "sorted" => "R", "list" => "t"}
 ```
 
 ## Ruby on Rails
@@ -121,18 +121,18 @@ used instead of the ranker that is shipped with LexoRanker.
 ### Character Spaces
 
 The default ranker for LexoRanker can also be customized with a different
-character space. Please note that if you do decide to customize it, you'll
-need to make sure your database and Ruby agree on the ranking of characters.
-This can be passed to LexoRanker with
-`LexoRanker.with_character_space(characterspace)`. The character space you pass
-in will need to respond to:
+character space. This can be passed to LexoRanker with:
+
+`LexoRanker::Ranker.new(characterspace: MyCustomCharacterSpace)` 
+
+The character space you pass in will need to respond to:
 
 - `ord(char) # convert a character to an ordinal value`
 - `char(ord) # convert an ordinal value to a character`
 - `min # the topmost ranking character in your character space`
 - `max # the bottommost ranking character in your character space`
 
-## Notes
+#### Notes about Character Spaces
 
 In order to use LexoRank, the database system you use must know how to
 lexicographically order the same way Ruby does. For MySQL that is generally

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ RSpec::Core::RakeTask.new(:spec)
 
 require "standard/rake"
 
-task default: %i[spec standard]
+task default: %i[spec standard:fix]

--- a/lib/lexoranker/rankable_methods/base.rb
+++ b/lib/lexoranker/rankable_methods/base.rb
@@ -32,7 +32,7 @@ module LexoRanker
         # @param ranker [Class] The class used to determine rankings
         # @param default_insert_pos [Symbol] the default position for newly created rankable elements to be placed.
         # @return [void]
-        def rankable_by(field: :rank, scope_by: nil, ranker: LexoRanker::Ranker, default_insert_pos: :bottom)
+        def rankable_by(field: :rank, scope_by: nil, ranker: LexoRanker::Ranker.new, default_insert_pos: :bottom)
           unless %i[top bottom].include?(default_insert_pos)
             raise ArgumentError,
               "#{default_insert_pos} is not a valid default_insert_position. Must be one of [:top, :bottom]"

--- a/lib/lexoranker/ranker.rb
+++ b/lib/lexoranker/ranker.rb
@@ -35,131 +35,163 @@ module LexoRanker
   # that uses lexicographic ordering to sort items in a list, rather than
   # numbers.
   class Ranker
-    class << self
-      ##
-      # Returns a LexoRank at the midpoint between the min and max character space. Used for when you need to rank only
-      # one item in a list
-      #
-      # @return [String] the new LexoRank
-      #
-      # @example Return a LexoRank with no previous or following items.
-      #   LexoRanker.only # => 'M'
-      def only
-        value_between(before: CharacterSpace.min, after: CharacterSpace.max)
-      end
+    # Returns the current object used as the character space. By default this is the built-in
+    # LexoRanker::Ranker::CharacterSpace class, but can be overridden in the constructor
+    #
+    # @return Object the current character set
+    attr_reader :character_space
 
-      ##
-      # Return a LexoRank that comes before what would be the first item of a LexoRanked list. If `first_item` is nil,
-      # returns a LexoRank for a list with one element
-      #
-      # @param first_value [String, NilClass] the first LexoRank value of the list the new rank will be inserted into
-      # @return [String] a LexoRank before first_value
-      #
-      # @example Return a LexoRank before `first_value`
-      #   LexoRanker.first('M') # => 'H'
-      #
-      # @example Return a LexoRank with a nil `first_value`
-      #   LexoRanker.first(nil) # => 'M'
-      def first(first_value)
-        value_between(before: CharacterSpace.min, after: first_value)
-      end
+    # @param character_space [#chr, #ord, #min, #max]
+    # @return LexoRanker::Ranker a ranker
+    #
+    # @example Create a new ranker with the default character space
+    #   ranker = LexoRanker::Ranker.new
+    #
+    # @example Create a ranker with a custom character space
+    #   class CustomCharacterSpace
+    #     CHARACTERS = %w[a b c d e]
+    #     def self.chr(ord)
+    #       CHARACTERS[ord]
+    #     end
+    #     def self.ord(chr)
+    #       CHARACTERS.index(chr)
+    #     end
+    #     def min
+    #       CHARACTERS.first
+    #     end
+    #     def max
+    #       CHARACTERS.last
+    #     end
+    #   end
+    #
+    #   custom_ranker = LexoRanker::Ranker.new(CustomCharacterSpace)
+    def initialize(character_space = CharacterSpace)
+      @character_space = character_space
+    end
 
-      ##
-      # Return a LexoRank that comes after what would be the last item of a LexoRanked list. If `last_item` is nil,
-      # returns a LexoRank for a list with one element
-      #
-      # @param last_value [String, NilClass] the last LexoRank value of the list the new rank will be inserted into
-      # @return [String] a LexoRank after last_value
-      #
-      # @example Return a LexoRank after `last_value`
-      #   LexoRanker.last('M') # => 'T'
-      #
-      # @example Return a Lexorank with a nil `last_value`
-      #   LexoRanker.last(nil) # => 'M'
-      def last(last_value)
-        value_between(before: last_value, after: CharacterSpace.max)
-      end
+    ##
+    # Returns a LexoRank at the midpoint between the min and max character space. Used for when you need to rank only
+    # one item in a list
+    #
+    # @return [String] the new LexoRank
+    #
+    # @example Return a LexoRank with no previous or following items.
+    #   LexoRanker.only # => 'M'
+    def only
+      value_between(before: character_space.min, after: character_space.max)
+    end
 
-      ##
-      # Return a LexoRank between `previous` and `following` arguments. Either argument can be called with `NilClass` to
-      # return a LexoRank that is after/before the passed argument, but not necessarily before/after any other particular
-      # element.
-      #
-      # Passing `NilClass` as an argument, and then attempting to insert a LexoRank into an existing list may end up with
-      # identical LexoRank rankings, which is invalid.
-      #
-      # @param previous [String, NilClass] the LexoRank that will be preceding the returned LexoRank
-      # @param following [String, NilClass] the LexoRank that will be following the returned LexoRank
-      # @return [String] a LexoRank between `previous` and `following`
-      #
-      # @example Return a LexoRank between `previous` and `following`
-      #   LexoRanker.between('M', 'T') # => 'R'
-      #
-      # @example Return a LexoRank anywhere before `following`
-      #   LexoRanker.between(nil, 'M') # => 'H'
-      def between(previous, following)
-        value_between(before: previous, after: following)
-      end
+    ##
+    # Return a LexoRank that comes before what would be the first item of a LexoRanked list. If `first_item` is nil,
+    # returns a LexoRank for a list with one element
+    #
+    # @param first_value [String, NilClass] the first LexoRank value of the list the new rank will be inserted into
+    # @return [String] a LexoRank before first_value
+    #
+    # @example Return a LexoRank before `first_value`
+    #   LexoRanker.first('M') # => 'H'
+    #
+    # @example Return a LexoRank with a nil `first_value`
+    #   LexoRanker.first(nil) # => 'M'
+    def first(first_value)
+      value_between(before: character_space.min, after: first_value)
+    end
 
-      ##
-      # Init a new LexoRanking for an already sorted list of elements
-      # @todo: Will cause issues with lists that have duplicate elements, either warn or fix.
-      # @todo: Balance List when generating list
-      #
-      # @param list [Array] the existing list to be assigned LexoRanks
-      # @return [Hash] a hash with key being the element of the list, and value being the assigned LexoRank
-      #
-      # @example Return a has with element => LexoRank hash
-      #   list = [1,2,3]
-      #   LexoRanker.init_from_array(list) # { 1 => 'M', 2 => 'T', 3 => 'W' }
-      def init_from_array(list)
-        raise ArgumentError, "`list` can not be nil" if list.nil?
+    ##
+    # Return a LexoRank that comes after what would be the last item of a LexoRanked list. If `last_item` is nil,
+    # returns a LexoRank for a list with one element
+    #
+    # @param last_value [String, NilClass] the last LexoRank value of the list the new rank will be inserted into
+    # @return [String] a LexoRank after last_value
+    #
+    # @example Return a LexoRank after `last_value`
+    #   LexoRanker.last('M') # => 'T'
+    #
+    # @example Return a Lexorank with a nil `last_value`
+    #   LexoRanker.last(nil) # => 'M'
+    def last(last_value)
+      value_between(before: last_value, after: character_space.max)
+    end
 
-        list.inject({}) { |memo, element| memo.merge({element => last(memo.values.last)}) }
-      end
+    ##
+    # Return a LexoRank between `previous` and `following` arguments. Either argument can be called with `NilClass` to
+    # return a LexoRank that is after/before the passed argument, but not necessarily before/after any other particular
+    # element.
+    #
+    # Passing `NilClass` as an argument, and then attempting to insert a LexoRank into an existing list may end up with
+    # identical LexoRank rankings, which is invalid.
+    #
+    # @param previous [String, NilClass] the LexoRank that will be preceding the returned LexoRank
+    # @param following [String, NilClass] the LexoRank that will be following the returned LexoRank
+    # @return [String] a LexoRank between `previous` and `following`
+    #
+    # @example Return a LexoRank between `previous` and `following`
+    #   LexoRanker.between('M', 'T') # => 'R'
+    #
+    # @example Return a LexoRank anywhere before `following`
+    #   LexoRanker.between(nil, 'M') # => 'H'
+    def between(previous, following)
+      value_between(before: previous, after: following)
+    end
 
-      private
+    ##
+    # Init a new LexoRanking for an already sorted list of elements
+    # @todo: Will cause issues with lists that have duplicate elements, either warn or fix.
+    # @todo: Balance List when generating list
+    #
+    # @param list [Array] the existing list to be assigned LexoRanks
+    # @return [Hash] a hash with key being the element of the list, and value being the assigned LexoRank
+    #
+    # @example Return a has with element => LexoRank hash
+    #   list = [1,2,3]
+    #   LexoRanker.init_from_array(list) # { 1 => 'M', 2 => 'T', 3 => 'W' }
+    def init_from_array(list)
+      raise ArgumentError, "`list` can not be nil" if list.nil?
 
-      # rubocop:disable Metrics/MethodLength
-      def value_between(before:, after:)
-        before ||= CharacterSpace.min
-        after ||= CharacterSpace.max
-        rank = ""
+      list.inject({}) { |memo, element| memo.merge({element => last(memo.values.last)}) }
+    end
 
-        (before.length + after.length).times do |i|
-          prev_char = get_char(before, i, CharacterSpace.min)
-          after_char = get_char(after, i, CharacterSpace.max)
+    private
 
-          if prev_char == after_char
-            rank += prev_char
-            next
-          end
+    # rubocop:disable Metrics/MethodLength
+    def value_between(before:, after:)
+      before ||= character_space.min
+      after ||= character_space.max
+      rank = ""
 
-          mid = mid_char(prev_char, after_char)
+      (before.length + after.length).times do |i|
+        prev_char = get_char(before, i, character_space.min)
+        after_char = get_char(after, i, character_space.max)
 
-          if mid == prev_char || mid == after_char
-            rank += prev_char
-            next
-          end
-
-          rank += mid
-          break
+        if prev_char == after_char
+          rank += prev_char
+          next
         end
 
-        raise InvalidRankError, "Computed rank #{rank} comes after the provided after rank #{after}" if rank >= after
+        mid = mid_char(prev_char, after_char)
 
-        rank
+        if mid == prev_char || mid == after_char
+          rank += prev_char
+          next
+        end
+
+        rank += mid
+        break
       end
 
-      # rubocop:enable Metrics/MethodLength
+      raise InvalidRankError, "Computed rank #{rank} comes after the provided after rank #{after}" if rank >= after
 
-      def mid_char(prev, after)
-        CharacterSpace.chr(((CharacterSpace.ord(prev) + CharacterSpace.ord(after)) / 2.0).round)
-      end
+      rank
+    end
 
-      def get_char(string, index, default)
-        (index >= string.length) ? default : string[index]
-      end
+    # rubocop:enable Metrics/MethodLength
+
+    def mid_char(prev, after)
+      character_space.chr(((character_space.ord(prev) + character_space.ord(after)) / 2.0).round)
+    end
+
+    def get_char(string, index, default)
+      (index >= string.length) ? default : string[index]
     end
 
     class CharacterSpace
@@ -198,7 +230,5 @@ module LexoRanker
         end
       end
     end
-
-    private_constant :CharacterSpace
   end
 end

--- a/spec/lexoranker/ranker_spec.rb
+++ b/spec/lexoranker/ranker_spec.rb
@@ -1,17 +1,37 @@
 # frozen_string_literal: true
 
 RSpec.describe LexoRanker::Ranker do
-  describe ".only" do
+  describe "#only" do
     it "returns a rank for the only position" do
-      expect(described_class.only).not_to be_nil
+      expect(described_class.new.only).not_to be_nil
     end
   end
 
-  describe ".first" do
+  describe ".new" do
+    context "with a custom character space" do
+      # This may need some work. It works for now, but it's probably pretty brittle.
+      let(:custom_character_space) do
+        chars = ("a".."z").to_a
+        dbl = class_double(LexoRanker::Ranker::CharacterSpace, min: chars.first, max: chars.last)
+        allow(dbl).to receive(:ord).with("a").and_return(chars.index("a"))
+        allow(dbl).to receive(:ord).with("z").and_return(chars.index("z"))
+        allow(dbl).to receive(:chr).with(13).and_return(chars[13])
+        dbl
+      end
+
+      it "uses the custom character space" do
+        ranker = described_class.new(custom_character_space)
+        ranker.only
+        expect(custom_character_space).to have_received(:min).twice
+      end
+    end
+  end
+
+  describe "#first" do
     context "with a present first lexorank" do
       it "returns a rank in the first position" do
         collection = %w[G M T]
-        rank = described_class.first(collection.first)
+        rank = described_class.new.first(collection.first)
         collection << rank
         expect(collection.sort).to eq([rank, "G", "M", "T"])
       end
@@ -19,16 +39,16 @@ RSpec.describe LexoRanker::Ranker do
 
     context "with a nil first lexorank" do
       it "returns a rank" do
-        expect(described_class.first(nil)).not_to be_nil
+        expect(described_class.new.first(nil)).not_to be_nil
       end
     end
   end
 
-  describe ".last" do
+  describe "#last" do
     context "with a present last lexorank" do
       it "returns a rank in the last position" do
         collection = %w[G M T]
-        rank = described_class.last(collection.last)
+        rank = described_class.new.last(collection.last)
         collection << rank
         expect(collection.sort).to eq(["G", "M", "T", rank])
       end
@@ -36,16 +56,16 @@ RSpec.describe LexoRanker::Ranker do
 
     context "with a nil last lexorank" do
       it "returns a rank" do
-        expect(described_class.last(nil)).not_to be_nil
+        expect(described_class.new.last(nil)).not_to be_nil
       end
     end
   end
 
-  describe ".between" do
+  describe "#between" do
     context "with a previous and following" do
       it "returns a rank between the before and after" do
-        collection = described_class.init_from_array([0, 1, 2, 3, 4, 5])
-        rank = described_class.between(collection[1], collection[2])
+        collection = described_class.new.init_from_array([0, 1, 2, 3, 4, 5])
+        rank = described_class.new.between(collection[1], collection[2])
         collection[:new_element] = rank
         expect(collection.sort_by { |_k, v| v }[2].first).to eq(:new_element)
       end
@@ -53,45 +73,62 @@ RSpec.describe LexoRanker::Ranker do
 
     context "with a nil previous and following" do
       it "returns a rank at the beginning of the collection" do
-        collection = described_class.init_from_array([0, 1, 2, 3])
-        rank = described_class.between(nil, collection[0])
+        collection = described_class.new.init_from_array([0, 1, 2, 3])
+        rank = described_class.new.between(nil, collection[0])
         expect(rank).to be < collection[0]
       end
     end
 
     context "with a previous and nil following" do
       it "returns a rank at the end of the collection" do
-        collection = described_class.init_from_array([0, 1, 2, 3])
-        rank = described_class.between(collection[3], nil)
+        collection = described_class.new.init_from_array([0, 1, 2, 3])
+        rank = described_class.new.between(collection[3], nil)
         expect(rank).to be > collection[3]
       end
     end
 
     context "with a before argument that comes after the after argument" do
       it "raises an invalid rank error" do
-        expect { described_class.between("S", "R") }.to raise_error(LexoRanker::InvalidRankError)
+        expect { described_class.new.between("S", "R") }.to raise_error(LexoRanker::InvalidRankError)
       end
     end
 
     context "with a multi-character rank where the first character matches" do
       it "returns a rank between the provided ranks" do
-        expect(described_class.between("ab", "ad")).to be_between("ab", "ad")
+        expect(described_class.new.between("ab", "ad")).to be_between("ab", "ad")
       end
     end
   end
 
-  describe "init_from_array" do
+  describe "#init_from_array" do
     context "when pass an array" do
       it "returns a hash, with the element as the key, and lexorank as the value" do
         collection = [1, 2, "three", 4, 5]
-        ranks = described_class.init_from_array(collection)
+        ranks = described_class.new.init_from_array(collection)
         expect(ranks.sort_by { |_k, v| v }.to_h.keys).to eq([1, 2, "three", 4, 5])
       end
     end
 
     context "when passed nil" do
       it "raises ArgumentError" do
-        expect { described_class.init_from_array(nil) }.to raise_error(ArgumentError)
+        expect { described_class.new.init_from_array(nil) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe "#character_space" do
+    context "with the default character space" do
+      it "returns LexoRanker::Ranker::CharacterSpace" do
+        ranker = described_class.new
+        expect(ranker.character_space).to eq LexoRanker::Ranker::CharacterSpace
+      end
+    end
+
+    context "with a custom character space" do
+      it "returns LexoRanker::Ranker::CharacterSpace" do
+        custom_character_space = class_double(LexoRanker::Ranker::CharacterSpace)
+        ranker = described_class.new(custom_character_space)
+        expect(ranker.character_space).to eq custom_character_space
       end
     end
   end


### PR DESCRIPTION
Log:
* Change Ranker to not be a Singleton class
Before now, we were just using `LexoRanker::Ranker`'s class methods to generate rankings, however with the need to:
  1. Have a different character space
  2. Potentially use different character spaces for different rankings the ranker has now been changed to an instance of the `LexoRanker::Ranker` class.
* Add initializer and attr to hold character space
* Remove CharacterSpace class references.
* Test that we are actually using the custom character space implementation.