### PR TITLE
Update `name` in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    LexoRanker (0.1.0)
+    lexoranker (0.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -102,8 +102,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  LexoRanker!
   activerecord
+  lexoranker!
   rake
   rspec
   rubocop-md

--- a/lexoranker.gemspec
+++ b/lexoranker.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/lexoranker/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "LexoRanker"
+  spec.name = "lexoranker"
   spec.version = LexoRanker::VERSION
   spec.authors = ["PJ Davis"]
   spec.email = ["pj.davis@gmail.com"]


### PR DESCRIPTION
Creating the gem with a weirdly capitalized name makes things hard. Lowercase the name makes it better.