### PR TITLE
Update .ranks_around_position to respect scope_by

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lexoranker (0.1.0)
+    lexoranker (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/lexoranker/rankable_methods/adapters/active_record.rb
+++ b/lib/lexoranker/rankable_methods/adapters/active_record.rb
@@ -36,8 +36,10 @@ module LexoRanker
             instance
           end
 
-          def ranks_around_position(id, position)
-            ranked.where.not(id: id).offset(position - 1).limit(2).pluck(:"#{rankable_column}")
+          def ranks_around_position(id, position, scope_value: nil)
+            scope = ranked.where.not(id: id)
+            scope = scope.where("#{rankable_scope}": scope_value) unless scope_value.nil?
+            scope.offset(position - 1).limit(2).pluck(:"#{rankable_column}")
           end
         end
 

--- a/lib/lexoranker/rankable_methods/adapters/sequel.rb
+++ b/lib/lexoranker/rankable_methods/adapters/sequel.rb
@@ -41,8 +41,10 @@ module LexoRanker
             instance
           end
 
-          def ranks_around_position(id, position)
-            ranked.exclude(id: id).offset(position - 1).limit(2).select(rankable_column).map(&:"#{rankable_column}")
+          def ranks_around_position(id, position, scope_value: nil)
+            scope = ranked.exclude(id: id)
+            scope = scope.where("#{rankable_scope}": scope_value) unless scope_value.nil?
+            scope.offset(position - 1).limit(2).select(rankable_column).map(&:"#{rankable_column}")
           end
         end
 

--- a/lib/lexoranker/rankable_methods/base.rb
+++ b/lib/lexoranker/rankable_methods/base.rb
@@ -143,7 +143,8 @@ module LexoRanker
         previous, following = if position.zero?
           [nil, ranked_collection.first]
         else
-          self.class.ranks_around_position(id, position)
+          scope_value = send(self.class.rankable_scope) if rankable_scoped?
+          self.class.ranks_around_position(id, position, scope_value: scope_value)
         end
 
         rank = self.class.rankable_ranker.between(previous, following)

--- a/lib/lexoranker/version.rb
+++ b/lib/lexoranker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LexoRanker
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/lexoranker/rankable_methods/adapters/sequel_spec.rb
+++ b/spec/lexoranker/rankable_methods/adapters/sequel_spec.rb
@@ -135,6 +135,31 @@ RSpec.describe "LexoRanker::RankableMethods::Adapters::Sequel" do
     end
   end
 
+  describe ".ranks_around_position" do
+    context "with only one element" do
+      let(:post) { post_class.create(title: "Post 1") }
+
+      it "is empty" do
+        expect(post_class.ranks_around_position(post.id, 1)).to be_empty
+      end
+    end
+
+    context "with a scope_by column" do
+      let(:rankable_opts) { {scope_by: :scope} }
+
+      before do
+        other_scope_posts = (0..2).map { |i| post_class.create(title: "Other Post #{i}", scope: "other") }
+        ranks = post_class.rankable_ranker.init_from_array(other_scope_posts)
+        other_scope_posts.each { |post| post.update(rank: ranks[post]) }
+      end
+
+      it "does not take into account other scope_by columns" do
+        post = post_class.create(title: "Post 1", scope: "scope")
+        expect(post_class.ranks_around_position(post.id, 1, scope_value: "scope")).to be_empty
+      end
+    end
+  end
+
   describe "#move_to_top" do
     let(:posts) do
       (0..2).map { |i| post_class.create(title: "Post #{i}") }


### PR DESCRIPTION
In the initial version, using a scope by would not effect the columns returned when calculating the before and after ranks for the position. This would cause problems when you expected rankings to be scoped to a column value, since `.ranks_around_position` would return all records, and could possibly cause an error when moving to a rank that didn't make sense in the concept of the scope, or ever worse, succeed in re-ranking the element, but in the wrong place.

`.ranks_around_position` now takes an optional `scope_value` keyword (defaults to nil) to be used in the where clause of the query to find the previous and next ranking values when moving a record to an absolute position.

This changes how the public methods `.ranks_around_position` and `#move_to` work, but in a backward compatable way. Thus the version bump to 0.2.0.