### PR TITLE
Bump Gem Version, Release 0.3.0 to RubyGems.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# built Gems
+*.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 2025-06-10
+* Release 0.3.0
+* Create initial RubyGems Release
+## 2025-06-09
 * Bump Gems to current versions
 * Replace StandardRB with Rubocop for running linter (still uses the
   StandardRB rules under the hood, but lets me configure the RSpec linter)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lexoranker (0.2.0)
+    lexoranker (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lexoranker.gemspec
+++ b/lexoranker.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/pjdavis/lexoranker"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 

--- a/lib/lexoranker/version.rb
+++ b/lib/lexoranker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LexoRanker
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Bumps the gem version to 0.3.0
Update the gemspec to show the required ruby version (at least 3.2) 
Prepare for initial release to Ruby Gems